### PR TITLE
Apacheサーバーの構築方法を変更＋Mecabの辞書をデフォルトに＋READMEに使用方法を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# ApacheのCGI関係
+server-cgi-bin/data
+server-cgi-bin/Apache24
+
+# node_modulesを除外
+server-mecab/server-mecab/node_modules

--- a/README.md
+++ b/README.md
@@ -18,4 +18,51 @@
 🔗 [類似文書を検索してネットワーク図を生成する](https://or-expert.com/?p=3841)  
 
 ## 🏅 受賞歴
-- 第８７回 情報処理学会 全国大会 学生奨励賞
+- 第８７回 情報処理学会 全国大会 学生奨励賞  
+  
+## ⚒️使用方法
+### [0]：動作環境と必要なツール
+Windows10以上のWindows環境で動作します。  
+これらのツールの事前インストールが必要です。  
+| ツール名                                                        | 動作確認したver |
+| --------------------------------------------------------------- | --------------- |
+| [Docker](https://www.docker.com/ja-jp/products/docker-desktop/) | 28.0.1          |
+| [gcc(C言語のコンパイラ)](https://www.mingw-w64.org/)            | 9.2.0           |
+  
+### [1]：リポジトリをクローン  
+クローンした後にcdで入ってください。
+```
+git clone https://github.com/o-zack-0390/DocumentsNetwork.git
+cd DocumentsNetwork
+```  
+  
+### [2]：`server-cgi-bin/data`に検索対象の文章データを配置
+`server-cgi-bin/data`に、検索対象の文章データを加工した後に手動で配置してください。ファイル名は必ず下記のリストと一致。  
+- `doc.txt`
+- `lbl.txt`
+- `uid.txt`
+- `wakachi.txt`
+- `wid.txt`
+  
+### [3]：バッチファイルを実行してApacheサーバーを構築＆起動
+`server-cgi-bin/1_setup.bat`を実行すると自動でApacheサーバーが構築されます。`server-cgi-bin/data`にあるファイルを生成される`Apache24`ディレクトリに全てコピーします。
+```
+server-cgi-bin\1_setup.bat
+```
+`server-cgi-bin/2_run.bat`を実行すると、構築したApacheサーバーを起動します。  
+```
+server-cgi-bin\2_run.bat
+```  
+  
+### [4]：クライアントとMecabのDockerコンテナを起動
+`settings`にあるDockerFileに基づき、クライアントとMecabのDockerコンテナを作成＆起動します。
+```
+docker compose up
+```
+
+### [5]：ブラウザで`http://localhost:3000/`を開きアプリを使用
+`http://localhost:3000/`にアクセスすることでアプリが使用できます。「Upload query document !」を押下して、検索クエリの文章データをアップロードした後に操作ができます。  
+  
+検索クエリの文章データの形式は以下の通りです。
+- 拡張子は`.csv`。
+- 最初の一行に検索クエリの文章データを改行コード無しで全部入れる。

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 ## 🏅 受賞歴
 - 第８７回 情報処理学会 全国大会 学生奨励賞  
   
+<br>  
+  
 ## ⚒️使用方法
 ### [0]：動作環境と必要なツール
 Windows10以上のWindows環境で動作します。  
@@ -29,12 +31,16 @@ Windows10以上のWindows環境で動作します。
 | [Docker](https://www.docker.com/ja-jp/products/docker-desktop/) | 28.0.1          |
 | [gcc(C言語のコンパイラ)](https://www.mingw-w64.org/)            | 9.2.0           |
   
+<br>  
+  
 ### [1]：リポジトリをクローン  
 クローンした後にcdで入ってください。
 ```
 git clone https://github.com/o-zack-0390/DocumentsNetwork.git
 cd DocumentsNetwork
 ```  
+  
+<br>  
   
 ### [2]：`server-cgi-bin/data`に検索対象の文章データを配置
 `server-cgi-bin/data`に、検索対象の文章データを加工した後に手動で配置してください。ファイル名は必ず下記のリストと一致させてください。  
@@ -43,6 +49,8 @@ cd DocumentsNetwork
 - `uid.txt`
 - `wakachi.txt`
 - `wid.txt`
+  
+<br>  
   
 ### [3]：バッチファイルを実行してApacheサーバーを構築＆起動
 server-cgi-binのディレクトリに入ってください。
@@ -60,12 +68,16 @@ cd server-cgi-bin
 
 補足：`server-cgi-bin/1_setup.bat`と`server-cgi-bin/2_run.bat`は、エクスプローラー上からダブルクリックで実行することもできます。
   
+<br>  
+  
 ### [4]：クライアントとMecabのDockerコンテナを起動
 `settings`にあるDockerFileに基づき、クライアントとMecabのDockerコンテナを作成＆起動します。
 ```
 docker compose up
 ```
-
+  
+<br>  
+  
 ### [5]：ブラウザで`http://localhost:3000/`を開きアプリを使用
 [3]と[4]の項目にあるApacheサーバーとDockerコンテナを起動した状態で、`http://localhost:3000/`にアクセスするとアプリが使用できます。  
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd DocumentsNetwork
 ```  
   
 ### [2]：`server-cgi-bin/data`に検索対象の文章データを配置
-`server-cgi-bin/data`に、検索対象の文章データを加工した後に手動で配置してください。ファイル名は必ず下記のリストと一致。  
+`server-cgi-bin/data`に、検索対象の文章データを加工した後に手動で配置してください。ファイル名は必ず下記のリストと一致させてください。  
 - `doc.txt`
 - `lbl.txt`
 - `uid.txt`
@@ -45,14 +45,20 @@ cd DocumentsNetwork
 - `wid.txt`
   
 ### [3]：バッチファイルを実行してApacheサーバーを構築＆起動
-`server-cgi-bin/1_setup.bat`を実行すると自動でApacheサーバーが構築されます。`server-cgi-bin/data`にあるファイルを生成される`Apache24`ディレクトリに全てコピーします。
+server-cgi-binのディレクトリに入ってください。
 ```
-server-cgi-bin\1_setup.bat
+cd server-cgi-bin
+```
+`server-cgi-bin/1_setup.bat`を実行すると、Apacheサーバーを自動構築します。構築時に`server-cgi-bin/data`に配置したファイルを`Apache24/cgi-bin/data`に全てコピーします。
+```
+1_setup.bat
 ```
 `server-cgi-bin/2_run.bat`を実行すると、構築したApacheサーバーを起動します。  
 ```
-server-cgi-bin\2_run.bat
+2_run.bat
 ```  
+
+補足：`server-cgi-bin/1_setup.bat`と`server-cgi-bin/2_run.bat`は、エクスプローラー上からダブルクリックで実行することもできます。
   
 ### [4]：クライアントとMecabのDockerコンテナを起動
 `settings`にあるDockerFileに基づき、クライアントとMecabのDockerコンテナを作成＆起動します。
@@ -61,7 +67,10 @@ docker compose up
 ```
 
 ### [5]：ブラウザで`http://localhost:3000/`を開きアプリを使用
-`http://localhost:3000/`にアクセスすることでアプリが使用できます。「Upload query document !」を押下して、検索クエリの文章データをアップロードした後に操作ができます。  
+[3]と[4]の項目にあるApacheサーバーとDockerコンテナを起動した状態で、`http://localhost:3000/`にアクセスするとアプリが使用できます。  
+
+「Upload query document !」を押下して、検索クエリの文章データをアップロードすると、グラフによる検索結果の可視化ができます。  
+詳細：[類似文書を検索してネットワーク図を生成する](https://or-expert.com/?p=3841)  
   
 検索クエリの文章データの形式は以下の通りです。
 - 拡張子は`.csv`。

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,29 +1,30 @@
 version: "3.9"
 services:
   client:
-      container_name: client
-      build:
-        context: .
-        dockerfile: ./settings/DockerfileClient
-      volumes:
+    container_name: client
+    build:
+      context: .
+      dockerfile: ./settings/DockerfileClient
+    volumes:
       - type: bind
         source: ./client
         target: /client
-      ports:
-        - 3000:3000
-      tty: true
+    ports:
+      - 3000:3000
+    tty: true
   mecab:
-      container_name: mecab
-      build:
-        context: .
-        dockerfile: ./settings/DockerfileMeCab
-      volumes:
+    container_name: mecab
+    build:
+      context: .
+      dockerfile: ./settings/DockerfileMeCab
+    volumes:
       - type: bind
         source: ./server-mecab
         target: /server-mecab
-      ports:
-        - 4000:4000
-      tty: true
+    ports:
+      - 4000:4000
+    tty: true
+  # CGIのC言語プログラムがDockerのUbuntu環境で動作しないので使用しない
   #cgi:
   #  container_name: cgi
   #  build:

--- a/server-cgi-bin/1_setup.bat
+++ b/server-cgi-bin/1_setup.bat
@@ -76,8 +76,12 @@ if not exist Apache24\bin\httpd.exe (
     @REM コンパイルしたCGIをApacheのサーバーに移動
     move main.cgi Apache24\cgi-bin\
 
-    @REM dataディレクトリにあるドキュメントをApacheのサーバーにコピー
+    @REM Apacheのサーバーのcgi-binにdataとresultのディレクトリを作成
+    @REM 重要：C言語のプログラムの仕様上、mkdirしないとエラーになります
     mkdir Apache24\cgi-bin\data
+    mkdir Apache24\cgi-bin\result
+
+    @REM dataディレクトリにあるドキュメントをApacheのサーバーにコピー
     copy data\ Apache24\cgi-bin\data
 
     echo Setup completed successfully!

--- a/server-cgi-bin/1_setup.bat
+++ b/server-cgi-bin/1_setup.bat
@@ -1,0 +1,96 @@
+@echo off
+REM setup.bat - 初期セットアップ
+
+echo Setting up portable Apache environment...
+
+@REM ディレクトリのパスを取得(バックスラッシュを修正する)
+for /f "delims=" %%i in ('powershell -Command "$pwd.Path.Replace('\', '/') + '/'"') do set CURR_DIR=%%i
+echo %CURR_DIR%
+
+
+REM Apache ZIP パッケージのダウンロードと展開
+if not exist Apache24\bin\httpd.exe (
+    echo Downloading Apache...
+    
+    @REM curl を使ってApacheをダウンロード（リダイレクトに対応）
+    curl -L -o apache.zip https://www.apachelounge.com/download/VS17/binaries/httpd-2.4.63-250207-win64-VS17.zip
+    
+    if not exist apache.zip (
+        echo Download failed. Please download manually.
+        goto manual_instructions
+    )
+    
+    echo Extracting Apache...
+    
+    @REM tarコマンドを使って展開
+    mkdir apache_temp
+    tar -xf apache.zip -C apache_temp
+    
+    @REM 展開したApache24フォルダをコピー
+    xcopy /E /I apache_temp\Apache24 Apache24
+    
+    @REM 一時ファイルを削除
+    rmdir /S /Q apache_temp
+    del apache.zip
+    
+    if not exist Apache24\bin\httpd.exe (
+        echo Extraction failed!
+        goto manual_instructions
+    )
+
+
+    @REM Apache設定ファイルの調整--------------------------
+    echo Configuring Apache...
+
+    @REM サーバーのルートディレクトリを設定
+    powershell -Command "(Get-Content Apache24\conf\httpd.conf) -replace 'c:/Apache24', '%CURR_DIR%Apache24' | Set-Content Apache24\conf\httpd.conf"
+    
+    @REM cgi_moduleを有効
+    powershell -Command "(Get-Content Apache24\conf\httpd.conf) -replace '#LoadModule cgi_module', 'LoadModule cgi_module' | Set-Content Apache24\conf\httpd.conf"
+
+    @REM CGI設定を追加(cgi-binのディレクトリにcgiファイルを配置)
+    echo ^<Directory "%CURR_DIR%Apache24\cgi-bin"^> >> Apache24\conf\httpd.conf
+    echo     Options +ExecCGI >> Apache24\conf\httpd.conf
+    echo     AddHandler cgi-script .cgi .exe >> Apache24\conf\httpd.conf
+    echo     Require all granted >> Apache24\conf\httpd.conf
+    echo ^</Directory^> >> Apache24\conf\httpd.conf
+    echo ScriptAlias /cgi-bin/ "%CURR_DIR%Apache24\cgi-bin\" >> Apache24\conf\httpd.conf
+
+    @REM テスト用のCGIを配置
+    (
+    echo @echo off
+    echo echo Content-Type: text/plain
+    echo echo.
+    echo echo CGI Test Successful
+    ) > %CURR_DIR%Apache24\cgi-bin\test.bat
+
+
+    @REM CGIをコンパイル(GCCのインストール必須)
+    gcc c_file\main.c c_file\copyFile.c c_file\mkwid.c ^
+    c_file\mklbl.c c_file\nnsk5.c c_file\mst.c  c_file\hml.c  ^
+    c_file\knn.c c_file\se.c  c_file\mds.c  c_file\ce.c ^
+    c_file\kk.c  c_file\cJSON.c  c_file\preprocess.c  ^
+    c_file\generateGraph.c c_file\generateNetwork.c ^
+    -o main.cgi -lm
+
+    @REM コンパイルしたCGIをApacheのサーバーに移動
+    move main.cgi Apache24\cgi-bin\
+
+    @REM dataディレクトリにあるドキュメントをApacheのサーバーにコピー
+    mkdir Apache24\cgi-bin\data
+    copy data\ Apache24\cgi-bin\data
+
+    echo Setup completed successfully!
+    pause
+    goto :eof
+
+    :manual_instructions
+    echo Please follow these steps manually:
+    echo 1. Visit https://www.apachelounge.com/download/
+    echo 2. Download the latest Win64 zip package
+    echo 3. Extract the Apache24 folder to this directory and rename it to 'Apache24'
+    echo 4. Run this script again after extraction
+)
+
+
+pause

--- a/server-cgi-bin/2_run.bat
+++ b/server-cgi-bin/2_run.bat
@@ -1,0 +1,26 @@
+@echo off
+REM run.bat - Apacheサーバー起動（フォアグラウンド実行）
+
+echo Starting Apache server in foreground mode...
+echo Press Ctrl+C to stop the server.
+echo.
+echo Server running at 
+echo http://localhost:80/
+echo.
+echo test CGI at
+echo http://localhost:80/cgi-bin/test.bat
+echo.
+echo NetworkGraph CGI at
+echo http://localhost:80/cgi-bin/main.cgi
+echo.
+start http://localhost:80/
+start http://localhost:80/cgi-bin/test.bat
+start http://localhost:80/cgi-bin/main.cgi
+echo.
+
+REM -k start ではなく -X を使用してフォアグラウンドで実行
+Apache24\bin\httpd.exe -X -f "%~dp0Apache24\conf\httpd.conf"
+
+REM このコマンドはサーバーが終了するまで戻らない
+echo Apache server has been stopped.
+pause

--- a/server-mecab/serverMecab.js
+++ b/server-mecab/serverMecab.js
@@ -1,9 +1,9 @@
-import express from 'express';
-import MeCab from 'mecab-async';
+import express from "express";
+import MeCab from "mecab-async";
 
 /* ==== Begin Function ==== */
 function preprocessing(text) {
-    /*
+  /*
         文章を以下の形式に整形する関数
         ・ 数値を 0 に統一
         ・ 「,」を「、」に置換
@@ -13,73 +13,72 @@ function preprocessing(text) {
         ・ アルファベットを小文字に統一
         ・ 記号を削除
     */
-    const punctuation = `!"#$%&'()*+\\-./:;<=>?@[\\]^_{|}~「」〔〕“”〈〉『』【】＆＊・（）＄＃＠。、？！｀＋￥％■※`;
-    const regexPunctuation = new RegExp(`[${punctuation}]`, 'g');
-    text = text.replace(/[0-9]+/g, '0');
-    text = text.replace(/,/g, '、');
-    text = text.replace(/\t/g, '');
-    text = text.replace(/[\n\r]/g, '');
-    text = text.replace(/\s+/g, '');
-    text = text.toLowerCase();
-    text = text.replace(regexPunctuation, '');
-    return text;
+  const punctuation = `!"#$%&'()*+\\-./:;<=>?@[\\]^_{|}~「」〔〕“”〈〉『』【】＆＊・（）＄＃＠。、？！｀＋￥％■※`;
+  const regexPunctuation = new RegExp(`[${punctuation}]`, "g");
+  text = text.replace(/[0-9]+/g, "0");
+  text = text.replace(/,/g, "、");
+  text = text.replace(/\t/g, "");
+  text = text.replace(/[\n\r]/g, "");
+  text = text.replace(/\s+/g, "");
+  text = text.toLowerCase();
+  text = text.replace(regexPunctuation, "");
+  return text;
 }
 
-function parseToWakachi(text, mecab)
-{
-    /* わかち書き文章を生成する関数 */
-    return new Promise((resolve, reject) => {
-        mecab.wakachi(text, (err, result) => {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(result);
-            }
-        });
+function parseToWakachi(text, mecab) {
+  /* わかち書き文章を生成する関数 */
+  return new Promise((resolve, reject) => {
+    mecab.wakachi(text, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
     });
+  });
 }
 /* ==== End Function ==== */
 
 /* ==== Begin MeCab Setting ==== */
-const dicDir  = "/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd";
-const mecab   = new MeCab();
-mecab.command = `mecab -d ${dicDir}`;
+// const dicDir  = "/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd";
+const mecab = new MeCab();
+// mecab.command = `mecab -d ${dicDir}`;
 /* ==== End MeCab Setting ==== */
 
 /* ==== Begin Server Setting ==== */
-const app           = express();
-const port          = process.env.PORT || 4000;
-const allowedOrigin = process.env.ALLOWED_ORIGIN || 'http://localhost:3000';
+const app = express();
+const port = process.env.PORT || 4000;
+const allowedOrigin = process.env.ALLOWED_ORIGIN || "http://localhost:3000";
 
 app.use(express.json());
 app.use((req, res, next) => {
-    res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
-    res.setHeader('Access-Control-Allow-Methods', '*');
-    res.setHeader('Access-Control-Allow-Headers', '*');
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    if (req.method === 'OPTIONS') {
-        return res.sendStatus(204); // No Content
-    }
-    next();
+  res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+  res.setHeader("Access-Control-Allow-Methods", "*");
+  res.setHeader("Access-Control-Allow-Headers", "*");
+  res.setHeader("Access-Control-Allow-Credentials", "true");
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(204); // No Content
+  }
+  next();
 });
 /* ==== End Server Setting ==== */
 
 /* ==== Begin POST Server ==== */
-app.post('/', async (req, res) => {
-    const text = req.body.text;
-    try {
-        let words = await preprocessing(text)
-            words = await parseToWakachi(words, mecab);
-        res.json({ wakachiSentence: words.join(' ') });
-    } catch (err) {
-        console.error(err);
-        res.status(500).send('わかち書き中にエラーが発生しました');
-    }
+app.post("/", async (req, res) => {
+  const text = req.body.text;
+  try {
+    let words = await preprocessing(text);
+    words = await parseToWakachi(words, mecab);
+    res.json({ wakachiSentence: words.join(" ") });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send("わかち書き中にエラーが発生しました");
+  }
 });
 /* ==== End POST Server ==== */
 
 /* ==== Begin PORT Setting ==== */
 app.listen(port, () => {
-    console.log(`Express server listening on port ${port}`);
+  console.log(`Express server listening on port ${port}`);
 });
 /* ==== End PORT Setting ==== */


### PR DESCRIPTION
## 発生している問題
###  [server-cgi-bin](https://github.com/o-zack-0390/DocumentsNetwork/tree/main/server-cgi-bin)のC言語のCGI「`main.cgi`」が上手く動作しない
- ローカルのWindows環境に構築したApacheサーバー上では、正常に動作。
- UbuntuのApacheサーバー(Dockerコンテナ)上では、POST時に原因不明のInternal Server Errorを返却。  
  
### [server-mecab](https://github.com/o-zack-0390/DocumentsNetwork/tree/main/server-mecab)で指定されている辞書のパスが無効
- 使用する辞書にmecab-ipadic-NEologdが指定されている。
- 現時点ではmecab-ipadic-NEologdの自動インストールが未実装なので上手く動作しない。

 
## 問題への対応
- C言語のCGI「`main.cgi`」を動かすApacheサーバーをローカルのWindows環境に構築する仕様に変更。
- 一時的に、使用するMecabの辞書をインストール不要のデフォルト辞書に変更。
- おまけ：READMEに具体的な使用方法を追加してみた。